### PR TITLE
V2 - Address initial loading of Pax & Update CopyStationsFromLocoToCoaches

### DIFF
--- a/v2/core/AutoEngineer.cs
+++ b/v2/core/AutoEngineer.cs
@@ -1,4 +1,4 @@
-﻿using GalaSoft.MvvmLight.Messaging;
+using GalaSoft.MvvmLight.Messaging;
 using Game.Events;
 using Game.Messages;
 using Game.State;
@@ -46,6 +46,7 @@ namespace RouteManager.v2.core
             LocoTelem.closestStation[locomotive]                = StationManager.GetClosestStation(locomotive);
             LocoTelem.closestStationNeedsUpdated[locomotive]    = false;
             LocoTelem.CenterCar[locomotive]                     = TrainManager.GetCenterCoach(locomotive);
+            LocoTelem.needToUpdatePassengerCoaches[locomotive]  = true;
 
             //Feature Ehancement #30
             LocoTelem.initialSpeedSliderSet[locomotive]         = false;

--- a/v2/core/StationManager.cs
+++ b/v2/core/StationManager.cs
@@ -206,17 +206,17 @@ namespace RouteManager.v2.core
                 //Keep going in the direction previously travelled...
                 else
                 {
-                    //If we are traveling torward Anderson from Silva
+                    //If we are traveling torward Silva from Anderson
                     if (LocoTelem.locoTravelingEastWard[locomotive])
                     {
-                        Logger.LogToDebug(String.Format("Loco {0} next station is to the west", locomotive.DisplayName), Logger.logLevel.Verbose);
-                        station = stringIdentToStation(orderedSelectedStations[currentIndex + 1]);
+                        Logger.LogToDebug(String.Format("Loco {0} next station is to the east", locomotive.DisplayName), Logger.logLevel.Debug);
+                        station = stringIdentToStation(orderedSelectedStations[currentIndex - 1]);
                         return station != null ? station : selectedPassengerStops.First();
                     }
                     else
                     {
-                        Logger.LogToDebug(String.Format("Loco {0} next station is to the east", locomotive.DisplayName), Logger.logLevel.Debug);
-                        station = stringIdentToStation(orderedSelectedStations[currentIndex - 1]);
+                        Logger.LogToDebug(String.Format("Loco {0} next station is to the west", locomotive.DisplayName), Logger.logLevel.Debug);
+                        station = stringIdentToStation(orderedSelectedStations[currentIndex + 1]);
                         return station != null ? station : selectedPassengerStops.First();
                     }
                 }

--- a/v2/core/TrainManager.cs
+++ b/v2/core/TrainManager.cs
@@ -225,12 +225,12 @@ namespace RouteManager.v2.core
 
             string currentStation = LocoTelem.currentDestination[locomotive].identifier;
             int currentStationIndex = DestinationManager.orderedStations.IndexOf(currentStation);
-            bool isEastWest = LocoTelem.locoTravelingEastWard[locomotive]; // true if traveling West
+            bool isTravelingEastWard = LocoTelem.locoTravelingEastWard[locomotive]; // true if traveling East
 
             // Determine the range of stations to include based on travel direction
-            IEnumerable<string> relevantStations = isEastWest ?
-                DestinationManager.orderedStations.Skip(currentStationIndex) :
-                DestinationManager.orderedStations.Take(currentStationIndex + 1).Reverse();
+            IEnumerable<string> relevantStations = isTravelingEastWard ?
+                DestinationManager.orderedStations.Take(currentStationIndex + 1).Reverse() :
+                DestinationManager.orderedStations.Skip(currentStationIndex);
 
             // Filter to include only selected stations
             HashSet<string> selectedStationIdentifiers = LocoTelem.SelectedStations[locomotive]


### PR DESCRIPTION
Possible fixes for two things
- Station selection on passenger cars not being updated
- Station selection for locomotives seemed to be reversed in regards to east vs west bound. (There might be more spots that this occurred)