### PR TITLE
V2 - Fixes for next station

### DIFF
--- a/v2/Dispatcher.cs
+++ b/v2/Dispatcher.cs
@@ -176,16 +176,23 @@ namespace RouteManager.v2
 
         private void clearDicts()
         {
-            LocoTelem.TransitMode.Clear();
-            LocoTelem.RMMaxSpeed.Clear();
-            LocoTelem.approachWhistleSounded.Clear();
             LocoTelem.locomotiveCoroutines.Clear();
-            LocoTelem.lowFuelQuantities.Clear();
+            LocoTelem.RouteMode.Clear();
+            LocoTelem.TransitMode.Clear();
+            LocoTelem.CenterCar.Clear();
+            LocoTelem.RMMaxSpeed.Clear();
+            LocoTelem.initialSpeedSliderSet.Clear();
+            LocoTelem.approachWhistleSounded.Clear();
+            LocoTelem.clearedForDeparture.Clear();
+            LocoTelem.locoTravelingEastWard.Clear();
+            LocoTelem.needToUpdatePassengerCoaches.Clear();
+            LocoTelem.closestStationNeedsUpdated.Clear();
             LocoTelem.closestStation.Clear();
             LocoTelem.currentDestination.Clear();
-            LocoTelem.clearedForDeparture.Clear();
-            LocoTelem.CenterCar.Clear();
-            LocoTelem.needToUpdatePassengerCoaches.Clear();
+            LocoTelem.previousDestinations.Clear();
+            LocoTelem.lowFuelQuantities.Clear();
+            LocoTelem.UIStationSelections.Clear();
+            LocoTelem.SelectedStations.Clear();
         }
 
 

--- a/v2/core/StationManager.cs
+++ b/v2/core/StationManager.cs
@@ -227,6 +227,13 @@ namespace RouteManager.v2.core
 
                 Logger.LogToDebug(String.Format("Current Index was calculated as: {0}", currentIndex), Logger.logLevel.Debug);
 
+                // Current station is not a selected station
+                if (currentIndex == -1)
+                {
+                    Logger.LogToDebug(String.Format("Loco {0} current station is not in the selected stations ... Defaulting to first stop", locomotive.DisplayName), Logger.logLevel.Verbose);
+                    return selectedPassengerStops.First();
+                }
+
                 //At first station go West
                 if (currentIndex == 0)
                 {

--- a/v2/core/StationManager.cs
+++ b/v2/core/StationManager.cs
@@ -189,8 +189,7 @@ namespace RouteManager.v2.core
             }
 
             //Get Selected menu items
-            List<string> selectedStationIdentifiers = LocoTelem.SelectedStations
-                .SelectMany(pair => pair.Value)
+            List<string> selectedStationIdentifiers = LocoTelem.SelectedStations[locomotive]
                 .Select(passengerStop => passengerStop.identifier)
                 .Distinct()
                 .ToList();


### PR DESCRIPTION
Fixes #65
- Fixed calculateNextStation to check if the current station is not in the selected stations and set a default if so
- Fixed getNextStation to only use stations selected for the current locomotive