### PR TITLE
Modified low fuel message

### DIFF
--- a/v2/core/AutoEngineer.cs
+++ b/v2/core/AutoEngineer.cs
@@ -355,21 +355,27 @@ namespace RouteManager.v2.core
                 {
                     if (LocoTelem.lowFuelQuantities[locomotive].Count != 0)
                     {
+                        //Handle if started without enough fuel, use currentDestination instead
+                        string holdLocationName = LocoTelem.currentDestination[locomotive].DisplayName;
+
+                        if (LocoTelem.previousDestinations[locomotive].Count > 0)
+                            holdLocationName = LocoTelem.previousDestinations[locomotive].Last().DisplayName;
+
                         //Generate warning for each type of low fuel.
                         foreach (KeyValuePair<string, float> type in LocoTelem.lowFuelQuantities[locomotive])
                         {
                             if (type.Key == "coal")
                             {
-                                Logger.LogToConsole(String.Format("Locomotive {0} is low on coal and is holding at {1}", Hyperlink.To(locomotive), LocoTelem.previousDestinations[locomotive].LastOrDefault().DisplayName));
+                                Logger.LogToConsole(String.Format("Locomotive {0} is low on coal and is holding at {1}", Hyperlink.To(locomotive), holdLocationName));
                             }
                             if (type.Key == "water")
                             {
-                                Logger.LogToConsole(String.Format("Locomotive {0} is low on water and is holding at {1}", Hyperlink.To(locomotive), LocoTelem.previousDestinations[locomotive].LastOrDefault().DisplayName));
+                                Logger.LogToConsole(String.Format("Locomotive {0} is low on water and is holding at {1}", Hyperlink.To(locomotive), holdLocationName));
                             }
 
                             if (type.Key == "diesel-fuel")
                             {
-                                Logger.LogToConsole(String.Format("Locomotive {0} is low on diesel and is holding at {1}", Hyperlink.To(locomotive), LocoTelem.previousDestinations[locomotive].LastOrDefault().DisplayName));
+                                Logger.LogToConsole(String.Format("Locomotive {0} is low on diesel and is holding at {1}", Hyperlink.To(locomotive), holdLocationName));
                             }
                         }
                         yield return new WaitForSeconds(30);

--- a/v2/core/AutoEngineer.cs
+++ b/v2/core/AutoEngineer.cs
@@ -355,11 +355,7 @@ namespace RouteManager.v2.core
                 {
                     if (LocoTelem.lowFuelQuantities[locomotive].Count != 0)
                     {
-                        //Handle if started without enough fuel, use currentDestination instead
                         string holdLocationName = LocoTelem.currentDestination[locomotive].DisplayName;
-
-                        if (LocoTelem.previousDestinations[locomotive].Count > 0)
-                            holdLocationName = LocoTelem.previousDestinations[locomotive].Last().DisplayName;
 
                         //Generate warning for each type of low fuel.
                         foreach (KeyValuePair<string, float> type in LocoTelem.lowFuelQuantities[locomotive])


### PR DESCRIPTION
- Changed to use currentDestination if no previousDestination was set (Fixes #67 - `System.NullReferenceException`, other issue is still unresolved)