### PR TITLE
Passenger station relationships

### DIFF
--- a/RouteManager/v2/Dispatcher.cs
+++ b/RouteManager/v2/Dispatcher.cs
@@ -29,6 +29,9 @@ namespace RouteManager.v2
             RouteManager.logger.LogToDebug("    Dispatcher Mod Manager".PadRight(30) + RouteManager.getModLoader());
             RouteManager.logger.LogToDebug("--------------------------------------------------------------------------------------------------");
 
+            //Hook the map load event to build route data at load. 
+            Messenger.Default.Register<MapDidLoadEvent>(this, GameMapLoaded);
+            
             //Hook the map unload event to gracefully stop all instances prior to map unload. 
             Messenger.Default.Register<MapDidUnloadEvent>(this, GameMapUnloaded);
 
@@ -249,6 +252,16 @@ namespace RouteManager.v2
 
                 clearDicts();
             }
+        }
+
+        private void GameMapLoaded(MapDidLoadEvent mapDidLoadEvent)
+        {
+            RouteManager.logger.LogToDebug("GAME MAP LOAD TRIGGERED");
+
+            StationInformation.BuildStationMap();
+            StationInformation.BuildOrderedList();
+
+            RouteManager.logger.LogToDebug("GAME MAP LOAD COMPLETE");
         }
     }
 }

--- a/RouteManager/v2/UI/routeManagerWindow.cs
+++ b/RouteManager/v2/UI/routeManagerWindow.cs
@@ -112,7 +112,7 @@ namespace RouteManager.v2.UI
         private static void BuildPanel()
         {
             var stopsLookup = PassengerStop.FindAll().ToDictionary(stop => stop.identifier, stop => stop);
-            List<PassengerStop> orderedStops = new string[] { "sylva", "dillsboro", "wilmot", "whittier", "ela", "bryson", "hemingway", "alarkajct", "cochran", "alarka", "almond", "nantahala", "topton", "rhodo", "andrews" }
+            List<PassengerStop> orderedStops = StationInformation.OrderedStations
                                .Select(id => stopsLookup[id])
                                .Where(ps => !ps.ProgressionDisabled)
                                .ToList();

--- a/RouteManager/v2/core/DestinationManager.cs
+++ b/RouteManager/v2/core/DestinationManager.cs
@@ -12,11 +12,6 @@ namespace RouteManager.v2.core
 {
     public static class DestinationManager
     {
-        public static readonly List<string> orderedStations = new List<string>
-        {
-            "sylva", "dillsboro", "wilmot", "whittier", "ela", "bryson", "hemingway", "alarkajct", "cochran", "alarka",
-            "almond", "nantahala", "topton", "rhodo", "andrews"
-        };
 
         //Update the list of stations to stop at.
         public static void SetStopStations(Car car, List<PassengerStop> selectedStops)

--- a/RouteManager/v2/core/StationManager.cs
+++ b/RouteManager/v2/core/StationManager.cs
@@ -79,7 +79,7 @@ namespace RouteManager.v2.core
                 .Distinct()
                 .ToList();
 
-            List<string> orderedStopStations = DestinationManager.orderedStations.Where(item => selectedStationIdentifiers.Contains(item)).ToList();
+            List<string> orderedStopStations = StationInformation.OrderedStations.Where(item => selectedStationIdentifiers.Contains(item)).ToList();
 
             int currentIndex = orderedStopStations.IndexOf(LocoTelem.closestStation[locomotive].Item1.identifier);
 
@@ -227,7 +227,7 @@ namespace RouteManager.v2.core
                 .ToList();
 
             //Convert selected menu items into an ordered list of station stops
-            List<string> orderedstopStations = DestinationManager.orderedStations.Where(item => selectedStationIdentifiers.Contains(item)).ToList();
+            List<string> orderedstopStations = StationInformation.OrderedStations.Where(item => selectedStationIdentifiers.Contains(item)).ToList();
 
             PassengerStop nextStop = calculateNextStation(orderedstopStations, LocoTelem.stopStations[locomotive], currentStation, locomotive);
 
@@ -573,7 +573,7 @@ namespace RouteManager.v2.core
                 .ToList();
 
             //Convert selected menu items into an ordered list of station stops
-            List<string> orderedstopStations = DestinationManager.orderedStations.Where(item => selectedStationIdentifiers.Contains(item)).ToList();
+            List<string> orderedstopStations = StationInformation.OrderedStations.Where(item => selectedStationIdentifiers.Contains(item)).ToList();
 
             currentStationIndex = orderedstopStations.IndexOf(currentStation.identifier);
 
@@ -582,11 +582,11 @@ namespace RouteManager.v2.core
             if (currentStationIndex < 0)
             {
                 //find the current station index
-                int closestIndex = DestinationManager.orderedStations.FindIndex(stop => stop.Equals(currentStation.identifier));
+                int closestIndex = StationInformation.OrderedStations.FindIndex(stop => stop.Equals(currentStation.identifier));
                 if (LocoTelem.locoTravelingEastWard[locomotive])
                 {
                     //what are the stops after this point?
-                    string nextStopStation = DestinationManager.orderedStations.Take(closestIndex - 1).Where(station => orderedstopStations.Contains(station)).Last();
+                    string nextStopStation = StationInformation.OrderedStations.Take(closestIndex - 1).Where(station => orderedstopStations.Contains(station)).Last();
 
                     if (nextStopStation != null)
                     {
@@ -603,7 +603,7 @@ namespace RouteManager.v2.core
                 else
                 {
                     //what are the stops after this point?
-                    string nextStopStation = DestinationManager.orderedStations.Skip(closestIndex + 1).Where(station => orderedstopStations.Contains(station)).First();
+                    string nextStopStation = StationInformation.OrderedStations.Skip(closestIndex + 1).Where(station => orderedstopStations.Contains(station)).First();
 
                     if (nextStopStation != null)
                     {

--- a/RouteManager/v2/core/TrainManager.cs
+++ b/RouteManager/v2/core/TrainManager.cs
@@ -213,7 +213,7 @@ namespace RouteManager.v2.core
             RouteManager.logger.LogToDebug(String.Format("Loco: {0} update coach station selection", locomotive.DisplayName), LogLevel.Verbose);
 
             string currentStation = LocoTelem.currentDestination[locomotive].identifier;
-            int currentStationIndex = DestinationManager.orderedStations.IndexOf(currentStation);
+            int currentStationIndex = StationInformation.OrderedStations.IndexOf(currentStation);
             bool isTravelingEastWard = LocoTelem.locoTravelingEastWard[locomotive]; // true if traveling East
 
             // Determine the range of stations to include based on travel direction
@@ -221,15 +221,15 @@ namespace RouteManager.v2.core
 
             if (StationManager.currentlyAtLastStation(locomotive))
             {
-                relevantStations = DestinationManager.orderedStations.Except(new List<String>() { LocoTelem.closestStation[locomotive].Item1.identifier });
+                relevantStations = StationInformation.OrderedStations.Except(new List<String>() { LocoTelem.closestStation[locomotive].Item1.identifier });
             }
             else if (isTravelingEastWard)
             {
-                relevantStations = DestinationManager.orderedStations.Take(currentStationIndex + 1).Reverse();
+                relevantStations = StationInformation.OrderedStations.Take(currentStationIndex + 1).Reverse();
             }
             else
             {
-                relevantStations = DestinationManager.orderedStations.Skip(currentStationIndex);
+                relevantStations = StationInformation.OrderedStations.Skip(currentStationIndex);
             }
 
             foreach (string identifier in relevantStations)
@@ -472,7 +472,7 @@ namespace RouteManager.v2.core
             RouteManager.logger.LogToDebug(String.Format("Loco: {0} update coach station selection", locomotive.DisplayName), LogLevel.Verbose);
 
             string currentStation = StationManager.GetClosestStation_dev(locomotive).Item1.identifier; //LocoTelem.currentDestination[locomotive].identifier;
-            int currentStationIndex = DestinationManager.orderedStations.IndexOf(currentStation);
+            int currentStationIndex = StationInformation.OrderedStations.IndexOf(currentStation);
             bool isTravelingEastWard = LocoTelem.locoTravelingEastWard[locomotive]; // true if traveling East
             IEnumerable<string> filteredStations;
 
@@ -480,7 +480,7 @@ namespace RouteManager.v2.core
 
             var stopsLookup = PassengerStop.FindAll().ToDictionary(stop => stop.identifier, stop => stop);
             RouteManager.logger.LogToDebug($"CopyStationsFromLocoToCoaches_dev() stopsLookup Complete");
-            List<PassengerStop> orderedStops = DestinationManager.orderedStations.Select(id => stopsLookup[id])
+            List<PassengerStop> orderedStops = StationInformation.OrderedStations.Select(id => stopsLookup[id])
                                                                                  .ToList();
             RouteManager.logger.LogToDebug($"CopyStationsFromLocoToCoaches_dev() orderedStops Complete");
             List<PassengerStop> stationsLeftOfMe = orderedStops.Skip(currentStationIndex + 1).ToList();

--- a/RouteManager/v2/dataStructures/StationInformation.cs
+++ b/RouteManager/v2/dataStructures/StationInformation.cs
@@ -91,19 +91,19 @@ namespace RouteManager.v2.dataStructures
             foreach(PassengerStop ps in Branches["main"])
             {
                 //add the current station to the list
-                OrderedStations.Add(ps.name);
+                OrderedStations.Add(ps.identifier);
 
                 //does it have any branches?
-                if(Stations[ps.name].Branches.Count > 0)
+                if(Stations[ps.identifier].Branches.Count > 0)
                 {
-                    Stations[ps.name].Branches.Sort();
+                    Stations[ps.identifier].Branches.Sort();
 
                     //now lets list the stations in each branch
-                    foreach (string branch in Stations[ps.name].Branches)
+                    foreach (string branch in Stations[ps.identifier].Branches)
                     {
                         foreach(PassengerStop station in Branches[branch])
                         {
-                            OrderedStations.Add(station.name);
+                            OrderedStations.Add(station.identifier);
                         }
                     }
                 }
@@ -114,7 +114,7 @@ namespace RouteManager.v2.dataStructures
 
         private static void GetStationData(PassengerStop station, string branch)
         {
-            if(!Stations.ContainsKey(station.name))
+            if(!Stations.ContainsKey(station.identifier))
             {
                 Vector3? pos0 =  station.TrackSpans.First()?.lower?.GetPosition();
                 Vector3? pos1 =  station.TrackSpans.First()?.upper?.GetPosition();
@@ -126,9 +126,9 @@ namespace RouteManager.v2.dataStructures
                     StationMapData data = new StationMapData((float)pos0?.x, (float)pos0?.y, (float)pos0?.z, (float)pos1?.x, (float)pos1?.y, (float)pos1?.z, (float)centre?.x, (float)centre?.y, (float)centre?.z, (float)len);
                     data.Branch = branch;
 
-                    Stations.Add(station.name, data);
+                    Stations.Add(station.identifier, data);
 
-                    RouteManager.logger.LogToDebug($"Station Data {station.name}: {(float)pos0?.x}, {(float)pos0?.y}, {(float)pos0?.z}, {(float)pos1?.x}, {(float)pos1?.y}, {(float)pos1?.z}, {(float)centre?.x}, {(float)centre?.y}, {(float)centre?.z}, {(float)len}");
+                    RouteManager.logger.LogToDebug($"Station Data {station.identifier}: {(float)pos0?.x}, {(float)pos0?.y}, {(float)pos0?.z}, {(float)pos1?.x}, {(float)pos1?.y}, {(float)pos1?.z}, {(float)centre?.x}, {(float)centre?.y}, {(float)centre?.z}, {(float)len}");
                 }
                 
             }
@@ -179,10 +179,10 @@ namespace RouteManager.v2.dataStructures
                     if (neighbourGroupId != branch)
                     {
                         //it's not, so let's check if we are already aware of the conencting branch
-                        if (!Stations[current.name].Branches.Contains(neighbourGroupId))
+                        if (!Stations[current.identifier].Branches.Contains(neighbourGroupId))
                         {
                             //not currently know, add to the list
-                            Stations[current.name].Branches.Add(neighbourGroupId);
+                            Stations[current.identifier].Branches.Add(neighbourGroupId);
                         }
                     }
                 }

--- a/RouteManager/v2/dataStructures/StationInformation.cs
+++ b/RouteManager/v2/dataStructures/StationInformation.cs
@@ -94,7 +94,7 @@ namespace RouteManager.v2.dataStructures
                 OrderedStations.Add(ps.identifier);
 
                 //does it have any branches?
-                if(Stations[ps.identifier].Branches.Count > 0)
+                if(Stations[ps.identifier].Branches.Count() > 0)
                 {
                     Stations[ps.identifier].Branches.Sort();
 

--- a/RouteManager/v2/dataStructures/StationInformation.cs
+++ b/RouteManager/v2/dataStructures/StationInformation.cs
@@ -123,8 +123,11 @@ namespace RouteManager.v2.dataStructures
 
                 if (pos0 != null && pos1 != null && centre != null && len != null) 
                 {
-                    StationMapData data = new StationMapData((float)pos0?.x, (float)pos0?.y, (float)pos0?.z, (float)pos1?.x, (float)pos1?.y, (float)pos1?.z, (float)centre?.x, (float)centre?.y, (float)centre?.z, (float)len);
+                    bool hardEndOfLine = station.neighbors.Count() <= 1;
+
+                    StationMapData data = new StationMapData((float)pos0?.x, (float)pos0?.y, (float)pos0?.z, (float)pos1?.x, (float)pos1?.y, (float)pos1?.z, (float)centre?.x, (float)centre?.y, (float)centre?.z, (float)len, hardEndOfLine);
                     data.Branch = branch;
+                    data.station = station;
 
                     Stations.Add(station.identifier, data);
 

--- a/RouteManager/v2/dataStructures/StationMapData.cs
+++ b/RouteManager/v2/dataStructures/StationMapData.cs
@@ -14,6 +14,12 @@ namespace RouteManager.v2.dataStructures
         public Vector3 Center { get; set; }
         public float Length { get; set; }
 
+        //branch this station belongs to
+        public string Branch {  get; set; } 
+
+        //branches connected to this station
+        public List<string> Branches { get; set; }
+
         //Point coordinates of the referenced station in the 3d map space.
         public StationMapData(float x0, float y0, float z0, float x1, float y1, float z1, float xc, float yc, float zc, float len)
         {
@@ -21,6 +27,7 @@ namespace RouteManager.v2.dataStructures
             Pos1 = new Vector3(x1, y1, z1);
             Center = new Vector3(xc, yc, zc);
             Length = len;
+            Branches = new List<string>();
         }
     }
 }

--- a/RouteManager/v2/dataStructures/StationMapData.cs
+++ b/RouteManager/v2/dataStructures/StationMapData.cs
@@ -1,8 +1,6 @@
-﻿using System;
+﻿using RollingStock;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using UnityEngine;
 
 namespace RouteManager.v2.dataStructures
@@ -12,22 +10,42 @@ namespace RouteManager.v2.dataStructures
         public Vector3 Pos0 { get; set; }
         public Vector3 Pos1 { get; set; }
         public Vector3 Center { get; set; }
-        public float Length { get; set; }
+        public float Length { get; set; } 
+        public string Branch {  get; set; } //branch this station belongs to
+        public List<string> Branches { get; set; } //branches connected to this station
 
-        //branch this station belongs to
-        public string Branch {  get; set; } 
+        private bool HardEOL; //only one neighbour
 
-        //branches connected to this station
-        public List<string> Branches { get; set; }
+        public PassengerStop station { get; set; }
+
+        public bool EndOfLine {
+            get 
+            {
+                if (HardEOL || station == null) {
+                    return true;
+                }
+
+                //check how many neighbours are enabled; 1 enabled neighbour = EOL, >1 enabled neighbour = !EOL
+                int availablestops = station.neighbors.Where(ps => !ps.ProgressionDisabled).Count();
+
+                return availablestops <= 1;
+                
+            }
+            private set { }
+        }
+
+        
 
         //Point coordinates of the referenced station in the 3d map space.
-        public StationMapData(float x0, float y0, float z0, float x1, float y1, float z1, float xc, float yc, float zc, float len)
+        public StationMapData(float x0, float y0, float z0, float x1, float y1, float z1, float xc, float yc, float zc, float len, bool endOfLine = false)
         {
             Pos0 = new Vector3(x0, y0, z0);
             Pos1 = new Vector3(x1, y1, z1);
             Center = new Vector3(xc, yc, zc);
             Length = len;
+            HardEOL = endOfLine;
             Branches = new List<string>();
         }
+
     }
 }

--- a/RouteManager/v2/harmonyPatches/RouteManagerUI.cs
+++ b/RouteManager/v2/harmonyPatches/RouteManagerUI.cs
@@ -257,7 +257,7 @@ namespace RouteManager.v2.harmonyPatches
                 {
                     //Define the list to bind to the vertical scroll bar.
                     var stopsLookup = PassengerStop.FindAll().ToDictionary(stop => stop.identifier, stop => stop);
-                    var orderedStops = new string[] { "sylva", "dillsboro", "wilmot", "whittier", "ela", "bryson", "hemingway", "alarkajct", "cochran", "alarka", "almond", "nantahala", "topton", "rhodo", "andrews" }
+                    var orderedStops = StationInformation.OrderedStations
                                        .Select(id => stopsLookup[id])
                                        .Where(ps => !ps.ProgressionDisabled)
                                        .ToList();


### PR DESCRIPTION
When a map is loaded:

1. The order of stations is dynamically determined (hard-coded orderedStops lists have been replaced with the dynamic lists)
2. All branch lines (carrying passengers) are discovered
3. The StationMapData is built (no longer using hard-coded values)
4. StationMapData now includes the branch that the station is on, as well as a list of other connected branches

This commit attempts to make a general solution that should work for any map, but does make some assumptions:

1. The first station returned by PassengerStop.FindAll() is the beginning of the main line
2. Branch lines on the ends of the main line are part of the main line (Sylva and Andrews are both technically branch lines)

